### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # dracor-tutorials
 A collection of tutorials to get you started with the DraCor API.
 
-Binder: https://mybinder.org/v2/gh/dracor-org/dracor-tutorials/master
+Binder: https://mybinder.org/v2/gh/dracor-org/dracor-tutorials/main


### PR DESCRIPTION
fixed link to fix error

("Could not resolve ref for gh:dracor-org/dracor-tutorials/master. Double check your URL. GitHub recently changed default branches from "master" to "main". Did you mean the "main" branch?")